### PR TITLE
Fix For Bad Auth None Stringifying

### DIFF
--- a/grnhse/harvest/api.py
+++ b/grnhse/harvest/api.py
@@ -22,7 +22,7 @@ class SessionAuthMixin(object):
 
     def _set_auth(self):
         if self._api_key is not None:
-            auth = (self._api_key, None)
+            auth = (self._api_key, '')
             self._session.auth = auth
 
 


### PR DESCRIPTION
## Description
Requests stringifies the password field (in this case `None`) which some greenhouse keys don't like. Just use the empty string instead.


This should fixes #2 