### PR TITLE
[DE-2173] Unpin requests

### DIFF
--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -24,7 +24,23 @@ jobs:
         if [ -f build-requirements.txt ]; then pip install -r build-requirements.txt; fi
     - name: Build package
       run: |
-        python setup.py -q sdist --dist-dir 'dist/'
+        UPDATE_VERSION="true" python setup.py -q sdist --dist-dir 'dist/'
+    - name: Rename package (legacy)
+      run: |
+        	# This is a re-implementation of the assemble.py method of versioning. It
+          # renames all generated packages files from:
+          #     {package}/dist/{package}.tar.gz ->
+          #         {package}/dist/{package}-r{timestamp}+git{shorthash}.tar.gz
+          timestamp="$(date '+%Y%m%d%H%M%S')"
+          for module in "dist"/*.tar.gz; do {
+            module_basename="$(basename "$module" .tar.gz)"
+            # Skip the rename if there's a VERSION file
+            if [ ! -f "VERSION" ]; then
+              new_name="$module_basename-r$timestamp+git${GIT_COMMIT:0:7}"
+              mv "$module" "dist/${new_name}.tar.gz"
+            fi
+          }; done
+
     - name: List contents of dist/
       run: |
         ls -al 'dist/'

--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -26,17 +26,17 @@ jobs:
       run: |
         UPDATE_VERSION="true" python setup.py -q sdist --dist-dir 'dist/'
     - name: Rename package (legacy)
+      # This is a re-implementation of the assemble.py method of versioning. It
+      # renames all generated packages files from:
+      #     dist/{package}.tar.gz ->
+      #         dist/{package}-r{timestamp}+git{shorthash}.tar.gz
+      # (Skip the rename if there's a VERSION file)
       run: |
-        	# This is a re-implementation of the assemble.py method of versioning. It
-          # renames all generated packages files from:
-          #     {package}/dist/{package}.tar.gz ->
-          #         {package}/dist/{package}-r{timestamp}+git{shorthash}.tar.gz
           timestamp="$(date '+%Y%m%d%H%M%S')"
           for module in "dist"/*.tar.gz; do {
             module_basename="$(basename "$module" .tar.gz)"
-            # Skip the rename if there's a VERSION file
             if [ ! -f "VERSION" ]; then
-              new_name="$module_basename-r$timestamp+git${GIT_COMMIT:0:7}"
+              new_name="$module_basename-r$timestamp+git${GITHUB_SHA:0:7}"
               mv "$module" "dist/${new_name}.tar.gz"
             fi
           }; done

--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 2
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         python -m pip install setuptools fabric pycrypto ecdsa
         if [ -f build-requirements.txt ]; then pip install -r build-requirements.txt; fi
     - name: Build package

--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -1,0 +1,27 @@
+name: Python package build and publish
+
+on:
+  push:
+    # branches: [ $default-branch ]
+    branches: [ githubbuilds ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 2
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install setuptools fabric pycrypto ecdsa
+        if [ -f build-requirements.txt ]; then pip install -r build-requirements.txt; fi
+    - name: Build package
+      run: |
+        python setup.py -q sdist --dist-dir 'dist/'

--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -25,3 +25,6 @@ jobs:
     - name: Build package
       run: |
         python setup.py -q sdist --dist-dir 'dist/'
+    - name: List contents of dist/
+      run: |
+        ls -al 'dist/'

--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    env:
+        PIP_INDEX_URL: ${{ secrets.PIP_INDEX_URL }}
+        PIPENV_PYPI_MIRROR: ${{ secrets.PIP_INDEX_URL }}
 
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        python -m pip install setuptools fabric pycrypto ecdsa pypi-uploader
+        python -m pip install setuptools fabric pycrypto ecdsa pypi-uploader noom_versioning
         if [ -f build-requirements.txt ]; then pip install -r build-requirements.txt; fi
     - name: Build package
       run: |

--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -3,7 +3,7 @@ name: Python package build and publish
 on:
   push:
     # branches: [ $default-branch ]
-    branches: [ githubbuilds ]
+    branches: [ master ]
 
 jobs:
   build:
@@ -19,8 +19,7 @@ jobs:
         python-version: 2
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
-        python -m pip install setuptools fabric pycrypto ecdsa pypi-uploader noom_versioning
+        python -m pip install --upgrade pip wheel setuptools fabric pycrypto ecdsa pypi-uploader noom_versioning
         if [ -f build-requirements.txt ]; then pip install -r build-requirements.txt; fi
       env:
           PIP_INDEX_URL: ${{ secrets.PIP_INDEX_URL }}

--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        python -m pip install setuptools fabric pycrypto ecdsa
+        python -m pip install setuptools fabric pycrypto ecdsa pypi-uploader
         if [ -f build-requirements.txt ]; then pip install -r build-requirements.txt; fi
     - name: Build package
       run: |
@@ -44,3 +44,9 @@ jobs:
     - name: List contents of dist/
       run: |
         ls -al 'dist/'
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: ${{ secrets.NOOM_PYPI_PUBLISH_USERNAME }}
+        password: ${{ secrets.NOOM_PYPI_PUBLISH_PASSWORD }}
+        repository_url: https://pypi.noom.com/

--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    env:
-        PIP_INDEX_URL: ${{ secrets.PIP_INDEX_URL }}
-        PIPENV_PYPI_MIRROR: ${{ secrets.PIP_INDEX_URL }}
 
     steps:
     - uses: actions/checkout@v2
@@ -25,28 +22,12 @@ jobs:
         python -m pip install --upgrade pip wheel
         python -m pip install setuptools fabric pycrypto ecdsa pypi-uploader noom_versioning
         if [ -f build-requirements.txt ]; then pip install -r build-requirements.txt; fi
+      env:
+          PIP_INDEX_URL: ${{ secrets.PIP_INDEX_URL }}
+          PIPENV_PYPI_MIRROR: ${{ secrets.PIP_INDEX_URL }}
     - name: Build package
       run: |
         UPDATE_VERSION="true" python setup.py -q sdist --dist-dir 'dist/'
-    - name: Rename package (legacy)
-      # This is a re-implementation of the assemble.py method of versioning. It
-      # renames all generated packages files from:
-      #     dist/{package}.tar.gz ->
-      #         dist/{package}-r{timestamp}+git{shorthash}.tar.gz
-      # (Skip the rename if there's a VERSION file)
-      run: |
-          timestamp="$(date '+%Y%m%d%H%M%S')"
-          for module in "dist"/*.tar.gz; do {
-            module_basename="$(basename "$module" .tar.gz)"
-            if [ ! -f "VERSION" ]; then
-              new_name="$module_basename-r$timestamp+git${GITHUB_SHA:0:7}"
-              mv "$module" "dist/${new_name}.tar.gz"
-            fi
-          }; done
-
-    - name: List contents of dist/
-      run: |
-        ls -al 'dist/'
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/grnhse/harvest/api.py
+++ b/grnhse/harvest/api.py
@@ -93,7 +93,7 @@ class Harvest(object):
             related = self._uris['related'].get(endpoint, None)
             return HarvestObject(endpoint,
                                  self._api_key, self._base_url,
-                                 self._handle_throttling, self._throttling_duration, self._throttling_retries
+                                 self._handle_throttling, self._throttling_duration, self._throttling_retries,
                                  uris.get('list'), uris.get('retrieve'),
                                  related=related)
         else:

--- a/grnhse/harvest/api.py
+++ b/grnhse/harvest/api.py
@@ -21,7 +21,7 @@ def throttled_api_call(func):
 
     def wrapper(self, *args, **kwargs):
         if not self._handle_throttling:
-            return func(self, *args, **kwargs)
+            return self.func(*args, **kwargs)
 
         if closure['requests_before_throttling_remaining'] == 0:
             seconds_since_last_request = (datetime.now() - closure['requests_before_throttling_remaining_timestamp']).total_seconds()
@@ -29,7 +29,7 @@ def throttled_api_call(func):
                 time.sleep(self._throttling_duration - seconds_since_last_request)
                 closure['throttling_retries'] = closure['throttling_retries'] + 1
 
-        response = func(self, *args, **kwargs)
+        response = self.func(*args, **kwargs)
 
         if response.status_code == requests.codes.too_many:
             if closure['throttling_retries'] <= self._throttling_retries:

--- a/grnhse/harvest/api.py
+++ b/grnhse/harvest/api.py
@@ -21,7 +21,7 @@ def throttled_api_call(func):
 
     def wrapper(self, *args, **kwargs):
         if not self._handle_throttling:
-            return self.func(*args, **kwargs)
+            return func(*args, **kwargs)
 
         if closure['requests_before_throttling_remaining'] == 0:
             seconds_since_last_request = (datetime.now() - closure['requests_before_throttling_remaining_timestamp']).total_seconds()
@@ -29,7 +29,7 @@ def throttled_api_call(func):
                 time.sleep(self._throttling_duration - seconds_since_last_request)
                 closure['throttling_retries'] = closure['throttling_retries'] + 1
 
-        response = self.func(*args, **kwargs)
+        response = func(*args, **kwargs)
 
         if response.status_code == requests.codes.too_many:
             if closure['throttling_retries'] <= self._throttling_retries:
@@ -205,7 +205,7 @@ class HarvestObject(SessionAuthMixin):
         return self._session.get(url, params=_params)
 
     def _get(self, url, params=True):
-        response = self._fetch(self, url, params)
+        response = self._fetch(url, params)
         if response.status_code == requests.codes.ok:
             self._process_header_links(response.headers)
             return response.json()

--- a/grnhse/harvest/api.py
+++ b/grnhse/harvest/api.py
@@ -14,7 +14,8 @@ from grnhse.util import extract_header_links, strf_dt
 
 def throttled_api_call(func):
     requests_before_throttling_remaining = None
-    requests_before_throttling_remaining_timestamp = None
+    requests_before_throttling_remaining_timestamp = 0
+    throttling_retries = 0
 
     def wrapper(self, *args, **kwargs):
         if not self._handle_throttling:
@@ -22,16 +23,19 @@ def throttled_api_call(func):
 
         if requests_before_throttling_remaining == 0:
             seconds_since_last_request = (datetime.now() - requests_before_throttling_remaining_timestamp).total_seconds()
-            if seconds_since_last_request < 10:
-                time.sleep(10 - seconds_since_last_request)
+            if seconds_since_last_request < self._throttling_duration:
+                time.sleep(self._throttling_duration - seconds_since_last_request)
+                throttling_retries += 1
 
         response = func(self, *args, **kwargs)
 
         if response.status_code == requests.codes.too_many:
-            requests_before_throttling_remaining = 0
-            requests_before_throttling_remaining_timestamp = datetime.now()
-            return wrapper(self, *args, **kwargs)
+            if throttling_retries <= self._throttling_retries:
+                requests_before_throttling_remaining = 0
+                requests_before_throttling_remaining_timestamp = datetime.now()
+                return wrapper(self, *args, **kwargs)
 
+        throttling_retries = 0
         headers = response.headers
         if 'X-RateLimit-Remaining' in headers:
             requests_before_throttling_remaining = int(headers.get('X-RateLimit-Remaining'))
@@ -58,10 +62,12 @@ class SessionAuthMixin(object):
 
 
 class Harvest(object):
-    def __init__(self, api_key=None, version='v1', handle_throttling=True):
+    def __init__(self, api_key=None, version='v1', handle_throttling=True, throttling_duration=10, throttling_retries=3):
         self._api_key = api_key
         self._version = version
         self._handle_throttling = handle_throttling
+        self._throttling_duration = throttling_duration
+        self._throttling_retries = throttling_retries
 
         self._api = api_versions.get(version, None)
         if self._api is None:
@@ -86,7 +92,8 @@ class Harvest(object):
         if uris is not None:
             related = self._uris['related'].get(endpoint, None)
             return HarvestObject(endpoint,
-                                 self._api_key, self._base_url, self._handle_throttling,
+                                 self._api_key, self._base_url,
+                                 self._handle_throttling, self._throttling_duration, self._throttling_retries
                                  uris.get('list'), uris.get('retrieve'),
                                  related=related)
         else:
@@ -101,7 +108,17 @@ class HarvestObject(SessionAuthMixin):
     _object_id = None
     _params = None
 
-    def __init__(self, name, api_key, base_url, handle_throttling, list_uri, retrieve_uri, related=None):
+    def __init__(
+            self,
+            name,
+            api_key,
+            base_url,
+            handle_throttling,
+            throttling_duration,
+            throttling_retries,
+            list_uri,
+            retrieve_uri,
+            related=None):
         super(HarvestObject, self).__init__(api_key)
 
         self._base_url = base_url
@@ -111,6 +128,8 @@ class HarvestObject(SessionAuthMixin):
         self._related = related
         self._name = name.replace('_', ' ').title()
         self._handle_throttling = handle_throttling
+        self._throttling_duration = throttling_duration
+        self._throttling_retries = throttling_retries
 
         self._next_url = None
         self._last_url = None
@@ -139,7 +158,8 @@ class HarvestObject(SessionAuthMixin):
                 uris['retrieve'].format(rel_id=self._object_id) if uris.get('retrieve') else None)
 
             return HarvestObject(endpoint,
-                                 self._api_key, self._base_url, self._handle_throttling,
+                                 self._api_key, self._base_url,
+                                 self._handle_throttling, self._throttling_duration, self._throttling_retries,
                                  list_uri, retrieve_uri)
         else:
             raise EndpointNotFound(endpoint)

--- a/grnhse/harvest/api.py
+++ b/grnhse/harvest/api.py
@@ -21,7 +21,7 @@ def throttled_api_call(func):
 
     def wrapper(self, *args, **kwargs):
         if not self._handle_throttling:
-            return func(*args, **kwargs)
+            return func(self, *args, **kwargs)
 
         if closure['requests_before_throttling_remaining'] == 0:
             seconds_since_last_request = (datetime.now() - closure['requests_before_throttling_remaining_timestamp']).total_seconds()
@@ -29,7 +29,7 @@ def throttled_api_call(func):
                 time.sleep(self._throttling_duration - seconds_since_last_request)
                 closure['throttling_retries'] = closure['throttling_retries'] + 1
 
-        response = func(*args, **kwargs)
+        response = func(self, *args, **kwargs)
 
         if response.status_code == requests.codes.too_many:
             if closure['throttling_retries'] <= self._throttling_retries:

--- a/grnhse/harvest/versions.py
+++ b/grnhse/harvest/versions.py
@@ -18,6 +18,9 @@ api_versions = {
                     'list': 'candidates',
                     'retrieve': 'candidates/{id}'
                 },
+                'candidate_custom_fields': {
+                    'list': 'custom_fields/candidate'
+                },
                 'close_reasons': {
                     'list': 'close_reasons'
                 },

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'mock',
     ],
     install_requires=[
-        'requests==2.20.1',
+        'requests~=2.20,>=2.20.1',
         'pytest-runner==4.2',
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def find_version():
 
 
 setup(
-    name='grnhse-api',
+    name='grnhse-api-lukatest',
     version=find_version(),
     author='Aaron Biller',
     author_email='aaronbiller@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import re
 
 from io import open
 from setuptools import setup, find_packages
+from noom_versioning.versioning import calver_version
 
 README = 'README.md'
 CHANGES = 'CHANGES.md'
@@ -27,7 +28,7 @@ def find_version():
 
 setup(
     name='grnhse-api-lukatest',
-    version=find_version(),
+    version=calver_version(),
     author='Aaron Biller',
     author_email='aaronbiller@gmail.com',
     description='Python wrapper for the Greenhouse APIs',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def find_version():
 
 
 setup(
-    name='grnhse-api-lukatest',
+    name='grnhse-api',
     version=calver_version(),
     author='Aaron Biller',
     author_email='aaronbiller@gmail.com',


### PR DESCRIPTION
Loosened requests version as libraries should never pin dependency versions. This is blocking upgrade to Airflow 2 as [Airflow works with requests==2.26.0.](https://github.com/apache/airflow/blob/constraints-2-2/constraints-3.7.txt#L461)